### PR TITLE
Show errors in the pattern as well as the text

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,6 +298,7 @@ impl<'a> FMatcher<'a> {
     /// the start and end of a string, as it is predicated on the `ignore_surrounding_blank_lines`
     /// option (i.e. don't use this to skip blank lines in the middle of the input, because that
     /// will fail if the user sets `ignore_surrounding_blank_lines` to `false`!).
+    #[allow(clippy::while_let_on_iterator)]
     fn skip_blank_lines(
         &self,
         lines: &mut Lines<'a>,
@@ -369,10 +370,8 @@ impl<'a> FMatcher<'a> {
                         if let Some(textm) = text_re.find(text) {
                             if self.options.distinct_name_matching {
                                 for (x, y) in names.iter() {
-                                    if x != &ptnm.as_str() {
-                                        if y == &textm.as_str() {
-                                            return false;
-                                        }
+                                    if x != &ptnm.as_str() && y == &textm.as_str() {
+                                        return false;
                                     }
                                 }
                             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -430,9 +430,9 @@ impl fmt::Display for FMatchError {
 
         let display_lines =
             |f: &mut fmt::Formatter, s: &str, lno_chars: usize, mark_line: usize| -> fmt::Result {
-                let mut num_lines = 0;
-                for (i, line) in s.lines().enumerate() {
-                    if mark_line == i + 1 {
+                let mut i = 1;
+                for line in s.lines() {
+                    if mark_line == i {
                         write!(
                             f,
                             "{} {}",
@@ -447,12 +447,12 @@ impl fmt::Display for FMatchError {
                     } else {
                         writeln!(f, "|{}", line)?;
                     }
-                    num_lines += 1;
-                    if mark_line == i + 1 {
+                    i += 1;
+                    if mark_line == i - 1 {
                         break;
                     }
                 }
-                if mark_line == num_lines + 1 {
+                if mark_line == i {
                     writeln!(f, "{}", ERROR_MARKER)?;
                 }
                 Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,7 +238,7 @@ impl<'a> FMatcher<'a> {
                         return Err(FMatchError {
                             ptn: self.ptn.to_owned(),
                             text: text.to_owned(),
-                            fail_line: text_lines_off,
+                            text_line_off: text_lines_off,
                         });
                     }
                 }
@@ -250,7 +250,7 @@ impl<'a> FMatcher<'a> {
                                 return Err(FMatchError {
                                     ptn: self.ptn.to_owned(),
                                     text: text.to_owned(),
-                                    fail_line: text_lines_off,
+                                    text_line_off: text_lines_off,
                                 });
                             }
                         }
@@ -262,7 +262,7 @@ impl<'a> FMatcher<'a> {
                         return Err(FMatchError {
                             ptn: self.ptn.to_owned(),
                             text: text.to_owned(),
-                            fail_line: text_lines_off,
+                            text_line_off: text_lines_off,
                         });
                     }
                 }
@@ -274,7 +274,7 @@ impl<'a> FMatcher<'a> {
                     return Err(FMatchError {
                         ptn: self.ptn.to_owned(),
                         text: text.to_owned(),
-                        fail_line: text_lines_off + skipped,
+                        text_line_off: text_lines_off + skipped,
                     });
                 }
             }
@@ -397,12 +397,12 @@ impl<'a> FMatcher<'a> {
 pub struct FMatchError {
     ptn: String,
     text: String,
-    fail_line: usize,
+    text_line_off: usize,
 }
 
 impl FMatchError {
-    pub fn failure_line(&self) -> usize {
-        self.fail_line
+    pub fn text_line_off(&self) -> usize {
+        self.text_line_off
     }
 }
 
@@ -428,11 +428,11 @@ impl fmt::Display for FMatchError {
             Ok(())
         }
 
-        writeln!(f, "Failed to match at line {}.\n", self.failure_line())?;
+        writeln!(f, "Failed to match at line {}.\n", self.text_line_off())?;
         writeln!(f, "Pattern:")?;
         display_lines(f, &self.ptn, lno_chars, None)?;
         writeln!(f, "\nText:")?;
-        display_lines(f, &self.text, lno_chars, Some(self.fail_line))
+        display_lines(f, &self.text, lno_chars, Some(self.text_line_off))
     }
 }
 
@@ -440,7 +440,7 @@ impl fmt::Display for FMatchError {
 /// uses `Debug` and doesn't interpret formatting characters when printing the panic message.
 impl fmt::Debug for FMatchError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Failed to match at line {}", self.fail_line)
+        write!(f, "Failed to match at line {}", self.text_line_off)
     }
 }
 
@@ -585,7 +585,7 @@ mod tests {
                 .unwrap()
                 .matches(text)
                 .unwrap_err()
-                .failure_line()
+                .text_line_off()
         };
 
         assert_eq!(helper("a\n...\nd", "a\nb\nc"), 3);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,8 +204,7 @@ impl<'a> FMatcher<'a> {
         FMBuilder::new(ptn)?.build()
     }
 
-    /// Does this fuzzy matcher match `text`? Returns `Ok(())` on success or `Err(usize)` on error
-    /// where the `usize` is the line number of the first line in `text` where the match failed.
+    /// Does this fuzzy matcher match `text`?
     pub fn matches(&self, text: &str) -> Result<(), FMatchError> {
         let mut names = HashMap::new();
         let mut ptn_lines = self.ptn.lines();


### PR DESCRIPTION
This PR ultimately moves things to the point that you get output such as:

```
Pattern (error at line 4):
    1: a
    2: b
    3: c
>>  4: d

Text (error at line 4):
    1: a
    2: b
    3: c
>>  4: z
```

Notice that we stop printing output after we've hit the "mark" (since it's not useful and just causes the console to scroll endlessly). I'm also no longer entirely sure if it's useful to print the line numbers out, given that we tell users the line elsewhere *and* show a mark. Thoughts?