### PR TITLE
Add the ability to show only local context around an error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -422,44 +422,36 @@ impl FMatchError {
 impl fmt::Display for FMatchError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // Figure out how many characters are required for the line numbers margin.
-        let max_line = usize::max(self.ptn_line_off, self.text_line_off);
         let err_mk_chars = ERROR_MARKER.chars().count() + ' '.len_utf8();
-        let lno_chars = usize::max(err_mk_chars, format!("{}", max_line).len());
 
-        let display_lines =
-            |f: &mut fmt::Formatter, s: &str, lno_chars: usize, mark_line: usize| -> fmt::Result {
-                let mut i = 1;
-                for line in s.lines() {
-                    if mark_line == i {
-                        write!(
-                            f,
-                            "{} {}",
-                            ERROR_MARKER,
-                            " ".repeat(err_mk_chars - err_mk_chars)
-                        )?;
-                    } else {
-                        write!(f, "{}", " ".repeat(lno_chars))?;
-                    }
-                    if line.is_empty() {
-                        writeln!(f, "|")?;
-                    } else {
-                        writeln!(f, "|{}", line)?;
-                    }
-                    i += 1;
-                    if mark_line == i - 1 {
-                        break;
-                    }
-                }
+        let display_lines = |f: &mut fmt::Formatter, s: &str, mark_line: usize| -> fmt::Result {
+            let mut i = 1;
+            for line in s.lines() {
                 if mark_line == i {
-                    writeln!(f, "{}", ERROR_MARKER)?;
+                    write!(f, "{} ", ERROR_MARKER)?;
+                } else {
+                    write!(f, "{}", " ".repeat(err_mk_chars))?;
                 }
-                Ok(())
-            };
+                if line.is_empty() {
+                    writeln!(f, "|")?;
+                } else {
+                    writeln!(f, "|{}", line)?;
+                }
+                i += 1;
+                if mark_line == i - 1 {
+                    break;
+                }
+            }
+            if mark_line == i {
+                writeln!(f, "{}", ERROR_MARKER)?;
+            }
+            Ok(())
+        };
 
         writeln!(f, "Pattern (error at line {}):", self.ptn_line_off)?;
-        display_lines(f, &self.ptn, lno_chars, self.ptn_line_off)?;
+        display_lines(f, &self.ptn, self.ptn_line_off)?;
         writeln!(f, "\nText (error at line {}):", self.text_line_off)?;
-        display_lines(f, &self.text, lno_chars, self.text_line_off)
+        display_lines(f, &self.text, self.text_line_off)
     }
 }
 


### PR DESCRIPTION
After simplifying the code (https://github.com/softdevteam/fm/commit/78f4827ccc8453e4ba7f848ccc372a02d96bed8e), the main point of this PR is to only show some lines of context around an error instead of the whole input (https://github.com/softdevteam/fm/commit/bfae6e152b5ffd6fca0c9040b9e478f3e488fe85). With this PR the output of an error on a long input looks as follows:

```
      Pattern (error at line 1000):
         ...
         |a997
         |a998
         |a999
      >> |a1000
         |a1001
         |a1002
         |a1003
         ...
    
      Text (error at line 1000):
         ...
         |a997
         |a998
         |a999
      >> |a1001
         |a1002
         |a1003
         |a1004
```