### PR TITLE
Add support for negative line matching.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ any other locations, it is matched literally.  Wildcard matching does not
 backtrack, so if a line consists solely of `...` then the next matching line
 anchors the remainder of the search.
 
+Lines can also be prefixed with `!!!` to indicate negative matching. This comes
+with several caveats:
+
+  * Negative wildcard-only matching `!!!...` is nonsensical and is disallowed.
+  * Consecutive negatively matched lines would cause backtracking and are
+    disallowed.
+  * Name matching (see belows) is allowed in negative lines but new name
+    matches on such lines are discarded.
+
 The following examples show `fm` in action using its defaults:
 
 ```rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -658,8 +658,7 @@ mod tests {
         assert!(!helper("a\n!!!b...", "a\nb"));
         assert!(helper("a\n!!!b...", "a\nc"));
         assert!(!helper("a\n!!!...c", "a\nbc"));
-        assert!(helper("a\n!!!b...c", "a\nbd"));
-        assert!(helper("a\n!!!b...c", "a\nb"));
+        assert!(!helper("a\n!!!...c...", "a\nbcd"));
     }
 
     #[test]


### PR DESCRIPTION
**DRAFT PR -- DO NOT MERGE**

A line `!!!a` matches any line that doesn't consist solely of 'a'. In one sense this is very simple: we just invert matching. However, negative line matching has some subtleties noted in the documentation:

  * Negative wildcard-only matching `!!!...` is nonsensical and is disallowed.
  * Consecutive negatively matched lines would cause backtracking and are disallowed.
  * Name matching is allowed in negative lines but new name matches on such lines are discarded.

@vext01 I'm not sure if I've thought through all the consequences of this: I'd be grateful if you could have a look (and, ideally, test it on real world data!) to see if this does a) what you need b) what you think it should do.