### PR TITLE
Implement grouping.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Edd Barrett <vext01@gmail.com>", "Laurence Tratt <laurie@tratt.net>"
 readme = "README.md"
 license = "Apache-2.0/MIT"
 categories = ["development-tools"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 regex = "1.8"

--- a/README.md
+++ b/README.md
@@ -1,19 +1,29 @@
 # fm
 
-`fm` is a simple non-backtracking fuzzy text matcher useful for matching
-multi-line patterns and text. At its most basic the wildcard operator `...`
-default) can be used in the following ways:
+`fm` is a simple fuzzy text matcher useful for matching multi-line patterns.
 
-  * If a line consists solely of `...` it means "match zero or more lines of text".
-  * If a line starts with `...`, the search is not anchored to the start of the line.
-  * If a line ends with `...`, the search is not anchored to the end of the line.
+Its core feature is the wildcard operator `...`, which can be used in the
+following ways:
+
+  * If a line consists solely of `...` it means "match zero or more lines of
+    text".
+  * If a line starts with `...`, the search is not anchored to the start of the
+    line.
+  * If a line ends with `...`, the search is not anchored to the end of the
+    line.
 
 Note that `...` can appear both at the start and end of a line and if a line
 consists of `......` (i.e. starts and ends with the wildcard with nothing
 inbetween), it will match exactly one line. If the wildcard operator appears in
-any other locations, it is matched literally.  Wildcard matching does not
-backtrack, so if a line consists solely of `...` then the next matching line
-anchors the remainder of the search.
+any other locations, it is matched literally.
+
+A line consisting solely of `...` searches until the next line/group in the
+pattern matches, which then anchors the remainder of the search: in other
+words, searching never backtracks beyond a line consisting solely of `...`.
+Each individual line constitutes a group *unless* the `(((` ... `)))` markers
+(where each marker must be on its own line) group together multiple lines into
+a single group. Within a group, line(s) can start/end with a wildcard but
+cannot solely consist of a wildcard.
 
 The following examples show `fm` in action using its defaults:
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,7 +343,6 @@ impl<'a> FMatcher<'a> {
                             Some(OPEN_GROUP) => {
                                 let ptn_lines_off_orig = ptn_lines_off;
                                 let text_lines_off_orig = text_lines_off;
-                                dbg!(ptn_lines_off, text_lines_off);
                                 // We now have to perform (bounded) backtracking
                                 ptnl = ptn_lines.next();
                                 ptn_lines_off += 1;


### PR DESCRIPTION
Previously, the following pattern:

```
...
a
b
```

matched as soon as "a" was found, so there was no way to express "I want to match an 'a' only if it's immediately followed by a 'b'". This commit maintains that behaviour but allows grouping. With this commit one can write:

```
...
(((
a
b
)))
```

to express this. In other words `(((\n...\n)))` "groups" together the lines inside and only matches if all the lines in there match. If it doesn't, it advances the search by one line and tries again.

I suppose it was inevitable at some point, but this turns fm into a limited, bounded, backtracking searcher. Whereas before the search was best case and worst case _O(n)_ (where *n* was the number of lines in the text (i.e. non-pattern)) the search is now best case _O(n)_ and worst case _O(n * m)_ (where *m* is the number of lines in the pattern).

For now this is a draft because a) I want to see if this matches what you both expected b) I would quite like some testing to see if it works in practise!