### PR TITLE
Interline wildcards

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Edd Barrett <vext01@gmail.com>", "Laurence Tratt <laurie@tratt.net>"
 readme = "README.md"
 license = "Apache-2.0/MIT"
 categories = ["development-tools"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 regex = "1.8"

--- a/README.md
+++ b/README.md
@@ -1,21 +1,111 @@
 # fm
 
-`fm` is a simple non-backtracking fuzzy text matcher useful for matching
-multi-line patterns and text. At its most basic, wildcard operators can be used
-in the following ways:
+`fm` is a simple limited backtracking fuzzy text matcher useful for matching
+multi-line *patterns* and *literal* text. Wildcard operators can be used to
+match parts of a line and to skip multiple lines of text. For example this
+*pattern*:
 
-  * If a line consists solely of `..?` it means "match zero or more lines of text".
-  * If a line starts with `...`, the search is not anchored to the start of the line.
-  * If a line ends with `...`, the search is not anchored to the end of the line.
+```text
+...A
+..?
+D...
+```
 
-Note that `...` can appear both at the start and end of a line and if a line
-consists of `......` (i.e. starts and ends with the wildcard with nothing
-inbetween), it will match exactly one line. If the wildcard operator appears in
-any other locations, it is matched literally. Wildcard matching does not
-backtrack, so if a line consists solely of `..?` then the next matching line
-anchors the remainder of the search.
+will successfully match against literals such as:
 
-The following examples show `fm` in action using its defaults:
+```text
+xyzA
+B
+C
+Dxyz
+```
+
+
+## Intraline matching
+
+The intraline wildcard operator `...` can appear at the start and/or end of a
+line. `...X...` matches any literal line that contains "X"; `...X` matches any
+literal line that ends with "X"; and `X...` matches any literal line that
+starts with "X". `......` matches exactly one literal line (i.e. the contents
+of the literal line are irrelevant but this will not match against the end
+of the literal text).
+
+## Interline matching
+
+There are two interline wildcard operators that determine when multiple literal
+lines are matched. Both match zero or more literal lines until a match for the
+next *item* is found, at which point the search is *anchored* (i.e.
+backtracking will not occur before the anchor). An item is either:
+
+  * A single pattern line.
+  * A group of pattern lines. A group is the sequence of pattern lines between
+    two interline wildcard operators or, if no wildcard operator is found, the
+    end of the pattern.
+
+The interline wildcards are:
+
+  * `..?` matches until it finds a match for the line immediately after the
+    interline operator, at which point the search is anchored.
+
+  * `..~` matches until it finds a match for the next group, at which point the
+    search is anchored.
+
+Consider this pattern:
+
+```text
+A
+..?
+B
+C
+..?
+```
+
+This will match successfully against the literal:
+
+```text
+A
+D
+B
+C
+E
+```
+
+but fail to match against the literal:
+
+```text
+A
+D
+B
+B
+C
+E
+```
+
+because the `..?` matched against the first "B", anchored the search, then
+immediately failed to match against the second "B".
+
+In contrast the pattern:
+
+```text
+A
+..~
+B
+C
+..?
+```
+
+will, through backtracing, successfully match the literal.
+
+There are two reasons why you should default to using `..?` rather than `..~`.
+Most obviously `..?` does not backtrack and has linear performance. Less
+obviously `..?` prevents literals from matching when they contain multiple
+similar sequences. Informally, `..?` makes for more rigorous testing: `..?` can
+be thought of as "the next thing that matches must look like X" whereas `..~`
+says "skip things that are almost like X until you find something that is
+definitely X". 
+
+
+## API
 
 ```rust
 use fm::FMatcher;

--- a/README.md
+++ b/README.md
@@ -30,12 +30,13 @@ starts with "X". `......` matches exactly one literal line (i.e. the contents
 of the literal line are irrelevant but this will not match against the end
 of the literal text).
 
+
 ## Interline matching
 
-There are two interline wildcard operators that determine when multiple literal
-lines are matched. Both match zero or more literal lines until a match for the
-next *item* is found, at which point the search is *anchored* (i.e.
-backtracking will not occur before the anchor). An item is either:
+There are two interline wildcard operators that match zero or more literal
+lines until a match for the next *item* is found, at which point the search is
+*anchored* (i.e. backtracking will not occur before the anchor). An item is
+either:
 
   * A single pattern line.
   * A group of pattern lines. A group is the sequence of pattern lines between
@@ -44,11 +45,17 @@ backtracking will not occur before the anchor). An item is either:
 
 The interline wildcards are:
 
-  * `...` matches until it finds a match for the line immediately after the
-    interline operator, at which point the search is anchored.
+  * The *prefix match* wildcard `...` matches until it finds a match for the
+    line immediately after the interline operator ("the prefix"), at which
+    point the search is anchored. This wildcard does not backtrack.
+  * The *group match* wildcard `..~` matches until it finds a match for the
+    next group, at which point the search is anchored. This wildcard
+    backtracks, though never further than one group.
 
-  * `..~` matches until it finds a match for the next group, at which point the
-    search is anchored.
+Interline wildcards cannot directly follow each other i.e. `...\n...?` is an
+invalid pattern. Interline wildcards can appear at the beginning or end of
+a pattern: at the end of a pattern, both interline wildcards have identical
+semantics to each other.
 
 Consider this pattern:
 
@@ -81,8 +88,8 @@ C
 E
 ```
 
-because the `...` matched against the first "B", anchored the search, then
-immediately failed to match against the second "B".
+because the `...` matches against the first "B", which anchors the search, then
+immediately fails to match against the second "B".
 
 In contrast the pattern:
 
@@ -94,15 +101,12 @@ C
 ...
 ```
 
-will, through backtracing, successfully match the literal.
+does match the literal because `..~` backtracks on the second "B".
 
 There are two reasons why you should default to using `...` rather than `..~`.
 Most obviously `...` does not backtrack and has linear performance. Less
-obviously `...` prevents literals from matching when they contain multiple
-similar sequences. Informally, `...` makes for more rigorous testing: `...` can
-be thought of as "the next thing that matches must look like X" whereas `..~`
-says "skip things that are almost like X until you find something that is
-definitely X". 
+obviously `...` is a more rigorous test, since it cannot skip prefix matches
+(i.e. the next line after the `...` in the pattern) in the literal.
 
 
 ## API

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # fm
 
 `fm` is a simple non-backtracking fuzzy text matcher useful for matching
-multi-line patterns and text. At its most basic the wildcard operator `...`
-default) can be used in the following ways:
+multi-line patterns and text. At its most basic, wildcard operators can be used
+in the following ways:
 
-  * If a line consists solely of `...` it means "match zero or more lines of text".
+  * If a line consists solely of `..?` it means "match zero or more lines of text".
   * If a line starts with `...`, the search is not anchored to the start of the line.
   * If a line ends with `...`, the search is not anchored to the end of the line.
 
 Note that `...` can appear both at the start and end of a line and if a line
 consists of `......` (i.e. starts and ends with the wildcard with nothing
 inbetween), it will match exactly one line. If the wildcard operator appears in
-any other locations, it is matched literally.  Wildcard matching does not
-backtrack, so if a line consists solely of `...` then the next matching line
+any other locations, it is matched literally. Wildcard matching does not
+backtrack, so if a line consists solely of `..?` then the next matching line
 anchors the remainder of the search.
 
 The following examples show `fm` in action using its defaults:
@@ -23,8 +23,8 @@ use fm::FMatcher;
 assert!(FMatcher::new("a").unwrap().matches("a").is_ok());
 assert!(FMatcher::new(" a ").unwrap().matches("a").is_ok());
 assert!(FMatcher::new("a").unwrap().matches("b").is_err());
-assert!(FMatcher::new("a\n...\nb").unwrap().matches("a\na\nb").is_ok());
-assert!(FMatcher::new("a\n...\nb").unwrap().matches("a\na\nb\nb").is_err());
+assert!(FMatcher::new("a\n..?\nb").unwrap().matches("a\na\nb").is_ok());
+assert!(FMatcher::new("a\n..?\nb").unwrap().matches("a\na\nb\nb").is_err());
 ```
 
 When a match fails, the matcher returns an error indicating the line number at

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ match parts of a line and to skip multiple lines of text. For example this
 
 ```text
 ...A
-..?
+...
 D...
 ```
 
@@ -44,7 +44,7 @@ backtracking will not occur before the anchor). An item is either:
 
 The interline wildcards are:
 
-  * `..?` matches until it finds a match for the line immediately after the
+  * `...` matches until it finds a match for the line immediately after the
     interline operator, at which point the search is anchored.
 
   * `..~` matches until it finds a match for the next group, at which point the
@@ -54,10 +54,10 @@ Consider this pattern:
 
 ```text
 A
-..?
+...
 B
 C
-..?
+...
 ```
 
 This will match successfully against the literal:
@@ -81,7 +81,7 @@ C
 E
 ```
 
-because the `..?` matched against the first "B", anchored the search, then
+because the `...` matched against the first "B", anchored the search, then
 immediately failed to match against the second "B".
 
 In contrast the pattern:
@@ -91,15 +91,15 @@ A
 ..~
 B
 C
-..?
+...
 ```
 
 will, through backtracing, successfully match the literal.
 
-There are two reasons why you should default to using `..?` rather than `..~`.
-Most obviously `..?` does not backtrack and has linear performance. Less
-obviously `..?` prevents literals from matching when they contain multiple
-similar sequences. Informally, `..?` makes for more rigorous testing: `..?` can
+There are two reasons why you should default to using `...` rather than `..~`.
+Most obviously `...` does not backtrack and has linear performance. Less
+obviously `...` prevents literals from matching when they contain multiple
+similar sequences. Informally, `...` makes for more rigorous testing: `...` can
 be thought of as "the next thing that matches must look like X" whereas `..~`
 says "skip things that are almost like X until you find something that is
 definitely X". 
@@ -113,8 +113,8 @@ use fm::FMatcher;
 assert!(FMatcher::new("a").unwrap().matches("a").is_ok());
 assert!(FMatcher::new(" a ").unwrap().matches("a").is_ok());
 assert!(FMatcher::new("a").unwrap().matches("b").is_err());
-assert!(FMatcher::new("a\n..?\nb").unwrap().matches("a\na\nb").is_ok());
-assert!(FMatcher::new("a\n..?\nb").unwrap().matches("a\na\nb\nb").is_err());
+assert!(FMatcher::new("a\n...\nb").unwrap().matches("a\na\nb").is_ok());
+assert!(FMatcher::new("a\n...\nb").unwrap().matches("a\na\nb\nb").is_err());
 ```
 
 When a match fails, the matcher returns an error indicating the line number at

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,52 +1,7 @@
+#![doc = include_str!("../README.md")]
+
 #![allow(clippy::upper_case_acronyms)]
 
-//! `fm` is a simple non-backtracking fuzzy text matcher useful for matching multi-line patterns
-//! and text. At its most basic, wildcard operators can be used in the following ways:
-//!
-//!   * If a line consists solely of `..?` it means "match zero or more lines of text".
-//!   * If a line starts with `...`, the search is not anchored to the start of the line.
-//!   * If a line ends with `...`, the search is not anchored to the end of the line.
-//!
-//! Note that `...` can appear both at the start and end of a line and if a line consists of
-//! `......` (i.e. starts and ends with the wildcard with nothing inbetween), it will match exactly
-//! one line. If the wildcard operator appears in any other locations, it is matched literally.
-//! Wildcard matching does not backtrack, so if a line consists solely of `..?` then the next
-//! matching line anchors the remainder of the search.
-//!
-//! The following examples show `fm` in action using its defaults:
-//!
-//! ```rust
-//! use fm::FMatcher;
-//!
-//! assert!(FMatcher::new("a").unwrap().matches("a").is_ok());
-//! assert!(FMatcher::new(" a ").unwrap().matches("a").is_ok());
-//! assert!(FMatcher::new("a").unwrap().matches("b").is_err());
-//! assert!(FMatcher::new("a\n..?\nb").unwrap().matches("a\na\nb").is_ok());
-//! assert!(FMatcher::new("a\n..?\nb").unwrap().matches("a\na\nb\nb").is_err());
-//! ```
-//!
-//! When a match fails, the matcher returns an error indicating the line number at which the match
-//! failed. The error can be formatted for human comprehension using the provided `Display`
-//! implementation.
-//!
-//! If you want to use non-default options, you will first need to use `FMBuilder` before having
-//! access to an `FMatcher`. For example, to use "name matching" (where you specify that the same
-//! chunk of text must appear at multiple points in the text, but without specifying exactly what
-//! the chunk must contain) you can set options as follows:
-//!
-//! ```rust
-//! use {fm::FMBuilder, regex::Regex};
-//!
-//! let ptn_re = Regex::new(r"\$.+?\b").unwrap();
-//! let text_re = Regex::new(r".+?\b").unwrap();
-//! let matcher = FMBuilder::new("$1 $1")
-//!                         .unwrap()
-//!                         .name_matcher(ptn_re, text_re)
-//!                         .build()
-//!                         .unwrap();
-//! assert!(matcher.matches("a a").is_ok());
-//! assert!(matcher.matches("a b").is_err());
-//! ```
 use std::{
     collections::hash_map::{Entry, HashMap},
     default::Default,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,8 +266,7 @@ pub struct FMatcher<'a> {
 }
 
 impl<'a> FMatcher<'a> {
-    /// A convenience method that automatically builds a pattern for you using `FMBuilder`'s
-    /// default options.
+    /// A convenience method that automatically builds a pattern using `FMBuilder` defaults.
     pub fn new(ptn: &'a str) -> Result<FMatcher, Box<dyn Error>> {
         FMBuilder::new(ptn)?.build()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ use std::{
 use regex::Regex;
 
 const ERROR_CONTEXT: usize = 3;
-const LINE_ANCHOR_WILDCARD: &str = "..?";
+const LINE_ANCHOR_WILDCARD: &str = "...";
 const GROUP_ANCHOR_WILDCARD: &str = "..~";
 const INTRALINE_WILDCARD: &str = "...";
 const ERROR_MARKER: &str = ">>";
@@ -186,15 +186,6 @@ impl<'a> FMBuilder<'a> {
 
     fn validate(&self) -> Result<(), Box<dyn Error>> {
         let lines = self.ptn.lines().map(|x| x.trim()).collect::<Vec<_>>();
-
-        for (i, l) in lines.iter().enumerate() {
-            if *l == "..." {
-                return Err(Box::<dyn Error>::from(format!(
-                    "'...' interline syntax on line {} is deprecated: use '..?' instead",
-                    i + 1
-                )));
-            }
-        }
 
         for i in 0..lines.len() {
             if i < lines.len() - 1
@@ -674,19 +665,19 @@ mod tests {
         assert!(helper("", "\n"));
         assert!(helper("a", "a"));
         assert!(!helper("a", "ab"));
-        assert!(helper("..?", ""));
-        assert!(helper("..?", "a"));
-        assert!(helper("..?", "a\nb"));
-        assert!(helper("..?\na", "a"));
-        assert!(helper("..?\na\n..?", "a"));
-        assert!(helper("a\n..?", "a"));
-        assert!(helper("a\n..?\nd", "a\nd"));
-        assert!(helper("a\n..?\nd", "a\nb\nc\nd"));
-        assert!(!helper("a\n..?\nd", "a\nb\nc"));
-        assert!(helper("a\n..?\nc\n..?\ne", "a\nb\nc\nd\ne"));
-        assert!(helper("a\n..?\n...b", "a\nb"));
-        assert!(helper("a\n..?\nb...", "a\nb"));
-        assert!(helper("a\n..?\nb...", "a\nbc"));
+        assert!(helper("...", ""));
+        assert!(helper("...", "a"));
+        assert!(helper("...", "a\nb"));
+        assert!(helper("...\na", "a"));
+        assert!(helper("...\na\n...", "a"));
+        assert!(helper("a\n...", "a"));
+        assert!(helper("a\n...\nd", "a\nd"));
+        assert!(helper("a\n...\nd", "a\nb\nc\nd"));
+        assert!(!helper("a\n...\nd", "a\nb\nc"));
+        assert!(helper("a\n...\nc\n...\ne", "a\nb\nc\nd\ne"));
+        assert!(helper("a\n...\n...b", "a\nb"));
+        assert!(helper("a\n...\nb...", "a\nb"));
+        assert!(helper("a\n...\nb...", "a\nbc"));
         assert!(helper("a\nb...", "a\nbc"));
         assert!(!helper("a\nb...", "a\nb\nc"));
         assert!(helper("a\n...b...", "a\nb"));
@@ -696,7 +687,7 @@ mod tests {
         assert!(!helper("a\n...b...", "a\nxb\nc"));
         assert!(!helper("a", "a\nb"));
         assert!(!helper("a\nb", "a"));
-        assert!(!helper("a\n..?\nb", "a"));
+        assert!(!helper("a\n...\nb", "a"));
         assert!(helper("a\n", "a\n"));
         assert!(helper("a\n", "a"));
         assert!(helper("a", "a\n"));
@@ -724,10 +715,10 @@ mod tests {
         assert!(helper("a\n..~\nc\nd\n", "a\nc\ne\nc\nd"));
         assert!(helper("a\n..~\nc\nd\ne", "a\nc\ne\nc\nd\ne"));
         assert!(helper("a\n..~\nc\n..~", "a\nb\nc"));
-        assert!(helper("a\n..~\nc\n..?", "a\nb\nc"));
+        assert!(helper("a\n..~\nc\n...", "a\nb\nc"));
         assert!(helper("a\n..~\nc\n..~\nd", "a\nb\nc\nd"));
         assert!(!helper("a\n..~\nc\n..~\nd", "a\nb\nc\ne"));
-        assert!(helper("a\n..~\nc\n..?\nd", "a\nb\nc\nd"));
+        assert!(helper("a\n..~\nc\n...\nd", "a\nb\nc\nd"));
         assert!(helper("a\n..~\nc\n..~\nd", "a\nb\nc\ne\nf\nd"));
         assert!(helper("a\n..~\nc\nd\n..~\nd", "a\nb\nc\nd\nd"));
         assert!(!helper("a\n..~\nc\nd\n..~\nd", "a\nb\nc\nd"));
@@ -778,22 +769,22 @@ mod tests {
         assert!(helper("", ""));
         assert!(helper("a", "a"));
         assert!(!helper("a", "ab"));
-        assert!(helper("..?", ""));
-        assert!(helper("..?", "a"));
+        assert!(helper("...", ""));
+        assert!(helper("...", "a"));
         assert!(helper("......", "a"));
         assert!(!helper("......", ""));
-        assert!(helper("..?", "a\nb"));
+        assert!(helper("...", "a\nb"));
         assert!(!helper("......", "a\nb"));
-        assert!(helper("..?\na", "a"));
-        assert!(helper("..?\na\n..?", "a"));
-        assert!(helper("a\n..?", "a"));
-        assert!(helper("a\n..?\nd", "a\nd"));
-        assert!(helper("a\n..?\nd", "a\nb\nc\nd"));
-        assert!(!helper("a\n..?\nd", "a\nb\nc"));
-        assert!(helper("a\n..?\nc\n..?\ne", "a\nb\nc\nd\ne"));
-        assert!(helper("a\n..?\n...b", "a\nb"));
-        assert!(helper("a\n..?\nb...", "a\nb"));
-        assert!(helper("a\n..?\nb...", "a\nbc"));
+        assert!(helper("...\na", "a"));
+        assert!(helper("...\na\n...", "a"));
+        assert!(helper("a\n...", "a"));
+        assert!(helper("a\n...\nd", "a\nd"));
+        assert!(helper("a\n...\nd", "a\nb\nc\nd"));
+        assert!(!helper("a\n...\nd", "a\nb\nc"));
+        assert!(helper("a\n...\nc\n...\ne", "a\nb\nc\nd\ne"));
+        assert!(helper("a\n...\n...b", "a\nb"));
+        assert!(helper("a\n...\nb...", "a\nb"));
+        assert!(helper("a\n...\nb...", "a\nbc"));
         assert!(helper("a\nb...", "a\nbc"));
         assert!(!helper("a\nb...", "a\nb\nc"));
         assert!(helper("a\n...b...", "a\nb"));
@@ -812,7 +803,7 @@ mod tests {
         assert!(helper("$1, $1, a", "a, a, a"));
         assert!(!helper("$1, $1, a", "a, a, b"));
         assert!(!helper("$1, $1, a", "a, b, a"));
-        assert!(helper("$1 $2\n..?\n$3 $2", "a X\nb Y\nc X"));
+        assert!(helper("$1 $2\n...\n$3 $2", "a X\nb Y\nc X"));
         assert!(!helper("ab$a", "a"));
         assert!(helper("$1\n$1...", "a\na b c"));
         assert!(!helper("$1\n$1...", "a\nb b c"));
@@ -849,7 +840,7 @@ mod tests {
         assert!(helper("$1, $1, a", "a, a, a"));
         assert!(!helper("$1, $1, a", "a, a, b"));
         assert!(!helper("$1, $1, a", "a, b, a"));
-        assert!(helper("$1 $2\n..?\n$3 $2", "a X\nb Y\nc X"));
+        assert!(helper("$1 $2\n...\n$3 $2", "a X\nb Y\nc X"));
         assert!(!helper("ab$a", "a"));
         assert!(helper("$1\n$1...", "a\na b c"));
         assert!(!helper("$1\n$1...", "a\nb b c"));
@@ -869,7 +860,7 @@ mod tests {
         assert!(helper("&1, &1, a", "a, a, a"));
         assert!(!helper("&1, &1, a", "a, a, b"));
         assert!(!helper("&1, &1, a", "a, b, a"));
-        assert!(helper("&1 &2\n..?\n&3 &2", "a X\nb Y\nc X"));
+        assert!(helper("&1 &2\n...\n&3 &2", "a X\nb Y\nc X"));
         assert!(!helper("ab&a", "a"));
         assert!(helper("&1\n&1...", "a\na b c"));
         assert!(!helper("&1\n&1...", "a\nb b c"));
@@ -884,7 +875,7 @@ mod tests {
         assert!(helper("$1 &1 $1", "a b a"));
         assert!(helper("$1 &1 &1", "a b b"));
         assert!(!helper("$1 &1 &1", "a b a"));
-        assert!(helper("$1 &2\n..?\n$3 &2", "a X\nb Y\nc X"));
+        assert!(helper("$1 &2\n...\n$3 &2", "a X\nb Y\nc X"));
         assert!(helper("$1 &1\n$1 &1...", "a b\na b c d"));
         assert!(helper("$1 &1\n$1 &1...", "a b\na b"));
         assert!(!helper("$1 &1\n$1 &1...", "a b\na a c d"));
@@ -914,7 +905,7 @@ mod tests {
             (err.ptn_line_off(), err.text_line_off())
         };
 
-        assert_eq!(helper("a\n..?\nd", "a\nb\nc"), (3, 3));
+        assert_eq!(helper("a\n...\nd", "a\nb\nc"), (3, 3));
         assert_eq!(helper("a\nb...", "a\nb\nc"), (3, 3));
         assert_eq!(helper("a\n...b...", "a\nxb\nc"), (3, 3));
 
@@ -935,9 +926,9 @@ mod tests {
         assert_eq!(helper("$1\n$1\na", "a\na\nb"), (3, 3));
         assert_eq!(helper("$1\n$1\na", "a\nb\na"), (2, 2));
 
-        assert_eq!(helper("..?\nb\nc\nd\n", "a\nb\nc\n0\ne"), (4, 4));
-        assert_eq!(helper("..?\nc\nd\n", "a\nb\nc\n0\ne"), (3, 4));
-        assert_eq!(helper("..?\nd\n", "a\nb\nc\n0\ne"), (2, 5));
+        assert_eq!(helper("...\nb\nc\nd\n", "a\nb\nc\n0\ne"), (4, 4));
+        assert_eq!(helper("...\nc\nd\n", "a\nb\nc\n0\ne"), (3, 4));
+        assert_eq!(helper("...\nd\n", "a\nb\nc\n0\ne"), (2, 5));
 
         assert_eq!(helper("a\n..~\nc\nd\ne", "a\nb\nc\nd"), (2, 2));
         assert_eq!(helper("a\n..~\nc\nd", "a\nb\nc\ne"), (2, 2));
@@ -974,7 +965,7 @@ mod tests {
 
     #[test]
     fn consecutive_wildcards_disallowed() {
-        match FMatcher::new("..?\n..?") {
+        match FMatcher::new("...\n...") {
             Err(e)
                 if e.to_string()
                     == "Can't have two consecutive interline wildcards lines at lines 1 and 2." =>
@@ -984,7 +975,7 @@ mod tests {
             x => panic!("{x:?}"),
         }
 
-        match FMatcher::new("..~\n..?") {
+        match FMatcher::new("..~\n...") {
             Err(e)
                 if e.to_string()
                     == "Can't have two consecutive interline wildcards lines at lines 1 and 2." =>
@@ -994,23 +985,10 @@ mod tests {
             x => panic!("{x:?}"),
         }
 
-        match FMatcher::new("a\nb\n..?\n..~") {
+        match FMatcher::new("a\nb\n...\n..~") {
             Err(e)
                 if e.to_string()
                     == "Can't have two consecutive interline wildcards lines at lines 3 and 4." =>
-            {
-                ()
-            }
-            x => panic!("{x:?}"),
-        }
-    }
-
-    #[test]
-    fn syntax_deprecation() {
-        match FMatcher::new("...") {
-            Err(e)
-                if e.to_string()
-                    == "'...' interline syntax on line 1 is deprecated: use '..?' instead" =>
             {
                 ()
             }


### PR DESCRIPTION
The most important commit here is https://github.com/softdevteam/fm/commit/ab7a1fe90b714565c65102864f84c3d4fbb70280 --- hopefully its commit message gives a decent overview of what this PR as a whole aims to do.

If this looks like what you were hoping this feature might be, then I will start to put in place the bits to be able to use it experimentally with yk (I have confirmed locally that with this change all yk's tests pass, but obviously none of them *need* the new feature yet).