### PR TITLE
Better reporting of errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,7 +299,6 @@ impl<'a> FMatcher<'a> {
                         ptn_lines_off += 1;
                         let mut ptn_lines_sub = ptn_lines.clone();
                         let mut ptnl_sub = ptnl;
-                        let mut ptn_lines_off_sub = ptn_lines_off;
                         let mut text_lines_sub = text_lines.clone();
                         let mut text_lines_off_sub = text_lines_off;
                         let mut textl_sub = textl;
@@ -314,7 +313,6 @@ impl<'a> FMatcher<'a> {
                                     // We've matched everything successfully
                                     ptn_lines = ptn_lines_sub;
                                     ptnl = ptnl_sub;
-                                    ptn_lines_off = ptn_lines_off_sub;
                                     text_lines = text_lines_sub;
                                     textl = textl_sub;
                                     text_lines_off = text_lines_off_sub;
@@ -347,7 +345,7 @@ impl<'a> FMatcher<'a> {
                                 (Some(x), Some(y)) => {
                                     if self.match_line(&mut names_sub, x, y) {
                                         ptnl_sub = ptn_lines_sub.next();
-                                        ptn_lines_off_sub += 1;
+                                        ptn_lines_off += 1;
                                         textl_sub = text_lines_sub.next();
                                         text_lines_off_sub += 1;
                                     } else {
@@ -355,7 +353,7 @@ impl<'a> FMatcher<'a> {
                                         // pattern, but advance the text.
                                         ptn_lines_sub = ptn_lines.clone();
                                         ptnl_sub = ptnl;
-                                        ptn_lines_off_sub = ptn_lines_off_orig;
+                                        ptn_lines_off = ptn_lines_off_orig;
                                         textl_sub = text_lines.next();
                                         text_lines_off += 1;
                                         text_lines_sub = text_lines.clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,6 +287,8 @@ impl<'a> FMatcher<'a> {
                             None => return Ok(()),
                         }
                     } else if x.trim() == GROUP_ANCHOR_WILDCARD {
+                        ptn_lines_off += 1;
+                        // We now have to perform (bounded) backtracking
                         let ptn_lines_off_orig = ptn_lines_off;
                         let text_lines_off_orig = text_lines_off;
                         ptnl = ptn_lines.next();
@@ -295,8 +297,6 @@ impl<'a> FMatcher<'a> {
                         if ptnl.is_none() {
                             return Ok(());
                         }
-                        // We now have to perform (bounded) backtracking
-                        ptn_lines_off += 1;
                         let mut ptn_lines_sub = ptn_lines.clone();
                         let mut ptnl_sub = ptnl;
                         let mut text_lines_sub = text_lines.clone();
@@ -1013,10 +1013,10 @@ mod tests {
         assert_eq!(helper("...\nc\nd\n", "a\nb\nc\n0\ne"), (3, 4));
         assert_eq!(helper("...\nd\n", "a\nb\nc\n0\ne"), (2, 5));
 
-        assert_eq!(helper("a\n..~\nc\nd\ne", "a\nb\nc\nd"), (2, 2));
-        assert_eq!(helper("a\n..~\nc\nd", "a\nb\nc\ne"), (2, 2));
-        assert_eq!(helper("a\n..~\nc\nd", "a\nc\ne\nc\ne"), (2, 2));
-        assert_eq!(helper("a\n..~\nc\nd\n...\nf", "a\ne\nf\nc\nd\ne"), (5, 6));
+        assert_eq!(helper("a\n..~\nc\nd\ne", "a\nb\nc\nd"), (3, 2));
+        assert_eq!(helper("a\n..~\nc\nd", "a\nb\nc\ne"), (3, 2));
+        assert_eq!(helper("a\n..~\nc\nd", "a\nc\ne\nc\ne"), (3, 2));
+        assert_eq!(helper("a\n..~\nc\nd\n...\nf", "a\ne\nf\nc\nd\ne"), (6, 6));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -355,7 +355,7 @@ impl<'a> FMatcher<'a> {
                                         // pattern, but advance the text.
                                         ptn_lines_sub = ptn_lines.clone();
                                         ptnl_sub = ptnl;
-                                        ptn_lines_off_sub += 1;
+                                        ptn_lines_off_sub = ptn_lines_off_orig;
                                         textl_sub = text_lines.next();
                                         text_lines_off += 1;
                                         text_lines_sub = text_lines.clone();
@@ -1018,6 +1018,7 @@ mod tests {
         assert_eq!(helper("a\n..~\nc\nd\ne", "a\nb\nc\nd"), (2, 2));
         assert_eq!(helper("a\n..~\nc\nd", "a\nb\nc\ne"), (2, 2));
         assert_eq!(helper("a\n..~\nc\nd", "a\nc\ne\nc\ne"), (2, 2));
+        assert_eq!(helper("a\n..~\nc\nd\n...\nf", "a\ne\nf\nc\nd\ne"), (5, 6));
     }
 
     #[test]


### PR DESCRIPTION
This PR fixes/changes a number of error location reporting "things". One is a clear bug (https://github.com/softdevteam/fm/commit/ba7da28553caa3a3c61c52f7fbbf3d7e7f320031) but two others (https://github.com/softdevteam/fm/commit/9794e4e9ceddd7721d8e8a1f61b0fa0380996964, https://github.com/softdevteam/fm/commit/6542ea4951fc336c8116b35991864fac9333fcd9) are "this makes finding what wrong easier" rather than "bug". Finally https://github.com/softdevteam/fm/commit/a1462a0df7c3b066b5e07c1cbb15d1b5b424916c is a different aspect of "make finding what wrong easier".

I've used each of these while debugging some fairly hairy pattern matching failures.