### PR TITLE
This once-deprecated field now causes an error.

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,5 +1,4 @@
 [licenses]
-unlicensed = "deny"
 confidence-threshold = 1.0
 allow = [
     "Apache-2.0",


### PR DESCRIPTION
The now-default behaviour is what we want, anyway.